### PR TITLE
Fix: Failed to minify CRA code due to this package

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es5",                          /* Specify ECMAScript target version: 'es3' (default), 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', or 'esnext'. */
     "module": "es2015",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2017", "es7", "es6", "dom"],   /* Specify library files to be included in the compilation. */
+    "lib": ["es2017", "es7", "es6", "dom", "es5"],   /* Specify library files to be included in the compilation. */
     "allowJs": false,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Package is now compiled to ES5 so CRA based application can use it in production ready apps.

Fixes #32


Also modified comment in tsconfig a bit, because according to this message the target should be lowercase:
<img width="1153" alt="Screenshot 2020-08-07 at 13 58 16" src="https://user-images.githubusercontent.com/15366622/89643892-0d2eb100-d8b7-11ea-84f5-3cdb5f51ecb6.png">
