### PR TITLE
Prevent config prop mutation

### DIFF
--- a/src/CSVReader.tsx
+++ b/src/CSVReader.tsx
@@ -334,7 +334,7 @@ export default class CSVReader extends React.Component<Props, State> {
     }
 
     if (config) {
-      options = Object.assign(config, options);
+      options = Object.assign({}, config, options);
     }
 
     reader.onload = (e: any) => {


### PR DESCRIPTION
I've noticed that once I pass config object to react-papaparse (worker or encoding for exmaple) then data is mutated.
For example:
1. Provide config object with encoding
2. Load first file & inspect "onDrop" returned data.
3. Remove first file.
4. Load second (different) file & inspect "onDrop" returned data.
You will see that this time, data is been aggregated with previous file data.

Please find the attach [CodeSanBox](https://codesandbox.io/s/react-papaparse-mutation-j780d?file=/src/App.js)

Disclaimer: 
I prefer the object spread rather then object assign but for the sake of similarity I kept it the same.