### PR TITLE
Add ability for data={} in CSVDownloader to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,27 @@ export default class CSVDownloader extends Component {
 }
 ```
 
+#### Data as a Function/callback
+
+`data={}` can be a function that returns a data object, e.g.
+```javascript
+<CSVDownloader
+  data={() => {
+    return [
+      {
+        "Column 1": "1-1",
+        "Column 2": "1-2",
+        "Column 3": "1-3",
+        "Column 4": "1-4",
+      }
+    ]}
+  }
+  // ... other props
+>
+  Download
+</CSVDownloader>
+```
+
 ### 🎀 readString
 
 ```javascript

--- a/src/CSVDownloader.tsx
+++ b/src/CSVDownloader.tsx
@@ -30,6 +30,9 @@ export default class CSVDownloader<T = any> extends React.Component<Props<T>> {
     const bomCode = bom ? '\ufeff' : '';
 
     let csvContent = null;
+    if (typeof data === 'function') {
+      data = data();
+    }
     if (typeof data === 'object') {
       csvContent = PapaParse.unparse(data, config);
     } else {


### PR DESCRIPTION
See issue #92 

this PR would allow CSVDownloader to call a function if passed in for data={} which would allow data to be calculated at click time instead of on every change to data.