### PR TITLE
Fixed onUploadAccepted signature when a preview is set

### DIFF
--- a/src/useCSVReader.tsx
+++ b/src/useCSVReader.tsx
@@ -328,7 +328,8 @@ function useCSVReaderComponent<T = any>() {
                         );
                         // setProgressBarPercentage(percentage);
                         if (data.length === config.preview) {
-                          onUploadAccepted(data, file);
+                          const obj = { data, errors, meta };
+                          onUploadAccepted(obj, file);
                         }
                       } else {
                         const cursor = row.meta.cursor;


### PR DESCRIPTION
Looks like we were passing the raw data to the `onUploadAccepted` function while we should pass a `ParseResult`.