### PR TITLE
Add optional required prop for input file

### DIFF
--- a/src/useCSVReader.tsx
+++ b/src/useCSVReader.tsx
@@ -40,6 +40,7 @@ export interface Props<T> {
   noDragEventsBubbling?: boolean;
   noKeyboard?: boolean;
   multiple?: boolean;
+  required?: boolean;
   preventDropOnDocument?: boolean;
   onUploadAccepted?: (
     data: ParseResult<T>,
@@ -72,6 +73,7 @@ function useCSVReaderComponent<T = any>() {
     noDragEventsBubbling = false,
     noKeyboard = false,
     multiple = false,
+    required = false,
     preventDropOnDocument = true,
     onUploadAccepted,
     validator,
@@ -552,6 +554,7 @@ function useCSVReaderComponent<T = any>() {
           const inputProps = {
             accept,
             multiple,
+            required,
             type: 'file',
             style: { display: 'none' },
             onChange: composeHandler(composeEventHandlers(onChange, onDropCb)),

--- a/test/__snapshots__/CSVReader.spec.tsx.snap
+++ b/test/__snapshots__/CSVReader.spec.tsx.snap
@@ -6,6 +6,7 @@ Array [
     accept="text/csv, .csv, application/vnd.ms-excel"
     autoComplete="off"
     multiple={false}
+    required={false}
     onChange={[Function]}
     onClick={[Function]}
     style={


### PR DESCRIPTION
fixes #123 

Note: The below error appears if the form is submitted without uploading the file. This happens because the input element is not visible visually. (`<input  ... style="display :none"/>`)
![image](https://user-images.githubusercontent.com/52914487/181023604-a9fbf511-3fdd-49d5-a36c-a7eb5eb4d9d8.png)
Also check this [issue](https://stackoverflow.com/questions/22148080/an-invalid-form-control-with-name-is-not-focusable) from SO