### PR TITLE
Allow readString config to be optional

### DIFF
--- a/src/readString.ts
+++ b/src/readString.ts
@@ -4,7 +4,7 @@ import { ReadStringConfig } from './model';
 
 export function readString<T>(
   csvString: string | typeof NODE_STREAM_INPUT,
-  config: ReadStringConfig<T> & {
+  config?: ReadStringConfig<T> & {
     download?: false | undefined;
     complete(results: ParseResult<T>): void;
   },

--- a/test/readString.spec.ts
+++ b/test/readString.spec.ts
@@ -1,10 +1,8 @@
 import expect from 'expect';
 import { readString } from '../src/readString';
 
-// eslint-disable-next-line no-undef
 describe('readString', () => {
-  // eslint-disable-next-line no-undef
-  it('should return an array as expected', function () {
+  it('should return an array as expected', function() {
     const fixtures = `Column 1,Column 2,Column 3,Column 4
 1-1,1-2,1-3,1-4
 2-1,2-2,2-3,2-4
@@ -19,10 +17,37 @@ describe('readString', () => {
     ];
     readString(fixtures, {
       worker: true,
-      complete: (results) => {
+      complete: (results: { data: string[][]; }) => {
         expect(Array.isArray(results.data)).toBe(true);
         expect(results.data).toEqual(expected);
       },
     });
+  });
+
+  it('should return an array as expected even without config', function() {
+    const fixtures = `Column 1,Column 2,Column 3,Column 4
+1-1,1-2,1-3,1-4
+2-1,2-2,2-3,2-4
+3-1,3-2,3-3,3-4
+4,5,6,7`;
+    const expected = {
+      "data": [
+        ["Column 1", "Column 2", "Column 3", "Column 4"],
+        ["1-1", "1-2", "1-3", "1-4"],
+        ["2-1", "2-2", "2-3", "2-4"],
+        ["3-1", "3-2", "3-3", "3-4"],
+        ["4", "5", "6", "7"]
+      ],
+      "errors": [],
+      "meta": {
+        "aborted": false,
+        "cursor": 91,
+        "delimiter": ",",
+        "linebreak": "\n",
+        "truncated": false
+      }
+    };
+    const result = readString(fixtures);
+    expect(result).toEqual(expected);
   });
 });

--- a/test/readString.spec.ts
+++ b/test/readString.spec.ts
@@ -24,7 +24,7 @@ describe('readString', () => {
     });
   });
 
-  it('should return an array as expected even without config', function() {
+  it('should return an array as expected without config', function() {
     const fixtures = `Column 1,Column 2,Column 3,Column 4
 1-1,1-2,1-3,1-4
 2-1,2-2,2-3,2-4


### PR DESCRIPTION
Config should not be required for readString, as there's a default config already applied. 